### PR TITLE
Fix IDL definition of ElementContentEditable

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
     <section data-dfn-for="ElementContentEditable">
         <h2>Extensions to the <dfn>ElementContentEditable</dfn> mixin</h2>
         <pre class="idl">
-            partial interface ElementContentEditable {
+            partial interface mixin ElementContentEditable {
                 [CEReactions] attribute DOMString virtualKeyboardPolicy;
            };
         </pre>


### PR DESCRIPTION
Base [`ElementContentEditable`](https://html.spec.whatwg.org/multipage/interaction.html#elementcontenteditable) interface is an `interface mixin`.

The `partial` definition needs to use `partial interface mixin` as a result per the Web IDL spec (see [partial interface mixin](https://heycam.github.io/webidl/#partial-interface-mixin)) definitions)