### PR TITLE
Fixing "string" to "empty string" (typo?)

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,11 +246,11 @@
         <p class="issue">
             Add handling of input and textarea.
           </p>
-        <p>The <dfn>virtualKeyboardPolicy</dfn> is an <a href=https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute>enumerated attribute</a> whose keywords are the <code>string</code>, <code>auto</code>, and <code>manual</code>. The IDL attribute must <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflect">reflect </a>the respective content attributes of the same name.
+        <p>The <dfn>virtualKeyboardPolicy</dfn> is an <a href=https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute>enumerated attribute</a> whose keywords are the <code>empty string</code>, <code>auto</code>, and <code>manual</code>. The IDL attribute must <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflect">reflect </a>the respective content attributes of the same name.
             When specified on an element that is a contenteditable host, <code>auto</code> causes the corresponding editable element to automatically show the VK when it is focused or tapped & <code>manual</code> 
             decouples focus and tap on the editable element from changes in the VK’s current state - the VK remains as it was.
             <br>
-            The change in setting of any {{ElementContentEditable/virtualKeyboardPolicy}} attribute value, negates currently defined behavior, unless it is a change from <code>auto</code> to <code >empty string</code> or vice versa.
+            The change in setting of any {{ElementContentEditable/virtualKeyboardPolicy}} attribute value, negates currently defined behavior, unless it is a change from <code>auto</code> to <code>empty string</code> or vice versa.
             <p class="issue">
                 Specify timing relative to events like focus.
             </p>


### PR DESCRIPTION
https://www.w3.org/TR/virtual-keyboard/#extensions-to-the-elementcontenteditable-mixin is quite confusing otherwise...